### PR TITLE
Fix error on crypto (missing digest) in Node >= 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function getDerivedKey(callback) {
 
 	}
 
-	crypto.pbkdf2(chromePassword, SALT, ITERATIONS, KEYLENGTH, callback);
+	crypto.pbkdf2(chromePassword, SALT, ITERATIONS, KEYLENGTH, 'sha1', callback);
 
 }
 


### PR DESCRIPTION
Add `digest` param to crypto.pbkdf2 call, set to `sha1`