### PR TITLE
Added Puppeteer & Custom Chrome Profile support out the box 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ chrome.getCookies('http://www.example.com/path/', function(err, cookies) {
 	puppeteerCookies = cookies;
 }, 'YourChromeProfile'); 
 
-// Profiles can be found in '~/Library/Application Support/Google/Chrome/${profile}' 
+// Profiles can be found in '~/Library/Application Support/Google/Chrome' 
 
 await page.waitFor(1000);
 await page.setCookie(...puppeteerCookies);

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install chrome-cookies-secure
 
 ## API
 
-getCookies(url[,format],callback)
+getCookies(url[,format],callback,profile)
 ---------------------------------
 
 `url` should be a fully qualified url, e.g. `http://www.example.com/path/`
@@ -23,6 +23,7 @@ curl | [Netscape HTTP Cookie File](http://curl.haxx.se/docs/http-cookies.html) c
 jar | cookie jar compatible with [request](https://www.npmjs.org/package/request)
 set-cookie | Array of Set-Cookie header values
 header | `cookie` header string, similar to what a browser would send
+puppeteer | an array of objects that can be loaded directly into puppeteer setCookie(...) for testing
 object | (default) Object where key is the cookie name and value is the cookie value. These are written in order so it's possible that duplicate cookie names will be overriden by later values
 
 If `format` is not specified, `object` will be used as the format by default.
@@ -35,7 +36,7 @@ basic usage
 -----------
 
 ```
-var chrome = require('chrome-cookies-secure');
+const chrome = require('chrome-cookies-secure');
 chrome.getCookies('http://www.example.com/path/', function(err, cookies) {
 	console.log(cookies);
 });
@@ -45,14 +46,34 @@ jar used with request
 ---------------------
 
 ```
-var request = require('request');
-var chrome = require('chrome-cookies-secure');
+const request = require('request');
+const chrome = require('chrome-cookies-secure');
 
 chrome.getCookies('http://www.example.com/', 'jar', function(err, jar) {
 	request({url: 'http://www.example.com/', jar: jar}, function (err, response, body) {
 		console.log(body);
 	});
 });
+
+```
+
+puppeteer with specific Chrome profile
+---------------------
+
+```
+const chrome = require('chrome-cookies-secure');
+const puppeteer = require('puppeteer')
+
+// puppeteer page launch stuff
+
+let puppeteerCookies;
+
+chrome.getCookies('http://www.example.com/path/', function(err, cookies) {
+	puppeteerCookies = cookies;
+}, 'Profile 24');
+
+await page.waitFor(1000);
+await page.setCookie(...puppeteerCookies);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ let puppeteerCookies;
 
 chrome.getCookies('http://www.example.com/path/', function(err, cookies) {
 	puppeteerCookies = cookies;
-}, 'YourChromeProfile'); // Profiles can be found in '~/Library/Application Support/Google/Chrome/${profile}' 
+}, 'YourChromeProfile'); 
+
+// Profiles can be found in '~/Library/Application Support/Google/Chrome/${profile}' 
 
 await page.waitFor(1000);
 await page.setCookie(...puppeteerCookies);

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ let puppeteerCookies;
 
 chrome.getCookies('http://www.example.com/path/', function(err, cookies) {
 	puppeteerCookies = cookies;
-}, 'Profile 24');
+}, 'YourChromeProfile'); // Profiles can be found in '~/Library/Application Support/Google/Chrome/${profile}' 
 
 await page.waitFor(1000);
 await page.setCookie(...puppeteerCookies);

--- a/example/puppeteer.js
+++ b/example/puppeteer.js
@@ -14,6 +14,8 @@ chrome.getCookies('https://yourURL.com', 'puppeteer', function(err, cookies) {
     cookiesToSave = cookies
 }, 'YourChromeProfile')
 
+// Profiles can be found in '~/Library/Application Support/Google/Chrome/${profile}' 
+
 // await page.waitFor(2000);
 await page.setCookie(...cookiesToSave);
 

--- a/example/puppeteer.js
+++ b/example/puppeteer.js
@@ -14,7 +14,7 @@ chrome.getCookies('https://yourURL.com', 'puppeteer', function(err, cookies) {
     cookiesToSave = cookies
 }, 'YourChromeProfile')
 
-// Profiles can be found in '~/Library/Application Support/Google/Chrome/${profile}' 
+// Profiles can be found in '~/Library/Application Support/Google/Chrome' 
 
 // await page.waitFor(2000);
 await page.setCookie(...cookiesToSave);

--- a/example/puppeteer.js
+++ b/example/puppeteer.js
@@ -1,0 +1,30 @@
+// const browser = await puppeteer.launch({ 
+//  // your args
+// });
+
+// const page = await browser.newPage();
+
+let cookiesToSave;
+
+chrome.getCookies('https://yourURL.com', 'puppeteer', function(err, cookies) {
+    if (err) {
+        console.log({message: 'error', err});
+        return
+    }
+    cookiesToSave = cookies
+}, 'YourChromeProfile')
+
+// await page.waitFor(2000);
+await page.setCookie(...cookiesToSave);
+
+// let result = await page.evaluate(() => {
+//     let stuff;
+//     // do stuff here
+//     return stuff; 
+// })
+// .catch((e) => {
+//     // catch any errors
+// });
+
+// browser.close();
+// return result

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ function convertRawToPuppeteerState(cookies) {
 		if (cookie.is_httponly) {
 			newCookieObject['HttpOnly'] = true
 		}
-        cookiesToSave.push(newCookieObject)
+        puppeteerCookies.push(newCookieObject)
 	})
 
 	return puppeteerCookies;

--- a/index.js
+++ b/index.js
@@ -223,10 +223,12 @@ function convertRawToObject(cookies) {
 	jar - request module compatible jar https://github.com/request/request#requestjar
 	set-cookie - Array of set-cookie strings
 	header - "cookie" header string
+	puppeteer - array of cookie objects that can be loaded straight into puppeteer setCookie(...)
 	object - key/value of name/value pairs, overlapping names are overwritten
 
  */
-const getCookies = function (uri, format, profile, callback) {
+
+const getCookies = async (uri, format, callback, profile) => {
 
 	profile ? profile : profile = 'Default'
 
@@ -284,6 +286,7 @@ const getCookies = function (uri, format, profile, callback) {
 			// ORDER BY tries to match sort order specified in
 			// RFC 6265 - Section 5.4, step 2
 			// http://tools.ietf.org/html/rfc6265#section-5.4
+			
 			db.each("SELECT host_key, path, is_secure, expires_utc, name, value, encrypted_value, creation_utc, is_httponly, has_expires, is_persistent FROM cookies where host_key like '%" + domain + "' ORDER BY LENGTH(path) DESC, creation_utc ASC", function (err, cookie) {
 
 				var encryptedValue,


### PR DESCRIPTION
1) Added new passable variable to getCookies - 'Puppeteer' - that allows one to retrieve cookies ready to load directly into Puppeteer without any additional formatting.

2) Added new variable to getCookies - 'Profile' - that allows one to select the Chrome Profile cookies they'd like to use / load. If none is given, the 'Default' Chrome Profile will be used.

3) Moved the root OS (& Chrome profile) detection to the point the 'getCookies' function is called, rather than when the module is initially loaded in NODEJS. The reason being it will crash an application if no 'Default' profile for Chrome exists (which the module previously assumed) and in my case wasn't present.

 