### PR TITLE
Updated readme & puppeteer examples

### DIFF
--- a/example/puppeteer.js
+++ b/example/puppeteer.js
@@ -1,32 +1,27 @@
-// const browser = await puppeteer.launch({ 
-//  // your args
-// });
+const chrome = require('chrome-cookies-secure');
+const puppeteer = require('puppeteer');
 
-// const page = await browser.newPage();
+const url = 'https://www.yourUrl.com/';
 
-let cookiesToSave;
+const getCookies = (callback) => {
+    chrome.getCookies(url, 'puppeteer', function(err, cookies) {
+        if (err) {
+            console.log(err, 'error');
+            return
+        }
+        console.log(cookies, 'cookies');
+        callback(cookies);
+    }, 'yourProfile') // e.g. 'Profile 2'
+}
 
-chrome.getCookies('https://yourURL.com', 'puppeteer', function(err, cookies) {
-    if (err) {
-        console.log({message: 'error', err});
-        return
-    }
-    cookiesToSave = cookies
-}, 'YourChromeProfile')
+getCookies(async (cookies) => {
+    const browser = await puppeteer.launch({ 
+        headless: false
+    });
+    const page = await browser.newPage();
 
-// Profiles can be found in '~/Library/Application Support/Google/Chrome' 
-
-// await page.waitFor(2000);
-await page.setCookie(...cookiesToSave);
-
-// let result = await page.evaluate(() => {
-//     let stuff;
-//     // do stuff here
-//     return stuff; 
-// })
-// .catch((e) => {
-//     // catch any errors
-// });
-
-// browser.close();
-// return result
+    await page.setCookie(...cookies);
+    await page.goto(url);
+    await page.waitFor(2000);
+    browser.close();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-cookies-secure",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "Extract encrypted Google Chrome cookies for a url on a Mac or Linux",
   "keywords": [
     "google",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-cookies-secure",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Extract encrypted Google Chrome cookies for a url on a Mac or Linux",
   "keywords": [
     "google",


### PR DESCRIPTION
Added javascript formatting and a better Puppeteer example to the README.MD. Also made a few tweaks to example urls by amending to https.

The Puppeteer example in the codebase now reflects the example in readme.