### PR TITLE
Bump win-dpapi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "keytar": "^5.0.0",
-    "win-dpapi": "^0.1.0"
+    "win-dpapi": "^1.1.0"
   }
 }


### PR DESCRIPTION
Fixes native build errors in recent versions of node.

Despite the semver-major bump, I don't believe there's actually any breaking changes.

[Compare changes](https://github.com/daguej/node-dpapi/compare/v0.1.0..v1.1.0)