### PR TITLE
Fix cookie domain match test

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,7 +358,7 @@ const getCookies = async (uri, format, callback, profile) => {
 						return;
 					}
 
-					if (!tough.domainMatch(host, cookie.host_key, true)) {
+					if (!tough.domainMatch(cookie.host_key, host, true)) {
 						return;
 					}
 


### PR DESCRIPTION
The sqlite query was searching for the domain and all subdomains by
prepending a wildcard `%` onto the `WHERE host_key LIKE` condition, but the
tough-cookie `domainMatch` check was throwing this away. Reversing the order
of the first two operands allows subdomains to match.

Here's that sqlite query:
```js
"SELECT host_key, path, is_secure, expires_utc, name, value, encrypted_value, creation_utc, is_httponly, has_expires, is_persistent FROM cookies where host_key like '%" + domain + "' ORDER BY LENGTH(path) DESC, creation_utc ASC"
```