### PR TITLE
Support arbitrary user-data-dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,23 +246,26 @@ function decryptAES256GCM(key, enc, nonce, tag) {
 
  */
 
-const getCookies = async (uri, format, callback, profile) => {
+const getCookies = async (uri, format, callback, profileOrPath) => {
 
-	profile ? profile : profile = 'Default'
+	if (/\//.test(profileOrPath))
+		path = profileOrPath;
+	else
+		profile = profileOrPath;
 
 	if (process.platform === 'darwin') {
 
-		path = process.env.HOME + `/Library/Application Support/Google/Chrome/${profile}/Cookies`;
+		path ? path : path = process.env.HOME + `/Library/Application Support/Google/Chrome/${profile}/Cookies`;
 		ITERATIONS = 1003;
 	
 	} else if (process.platform === 'linux') {
 	
-		path = process.env.HOME + `/.config/google-chrome/${profile}/Cookies`;
+		path ? path : path = process.env.HOME + `/.config/google-chrome/${profile}/Cookies`;
 		ITERATIONS = 1;
 	
 	} else if (process.platform === 'win32') {
 
-		path = os.homedir() + `\\AppData\\Local\\Google\\Chrome\\User Data\\${profile}\\Cookies`;
+		path ? path : path = os.homedir() + `\\AppData\\Local\\Google\\Chrome\\User Data\\${profile}\\Cookies`;
 
 	} else {
 	
@@ -358,7 +361,7 @@ const getCookies = async (uri, format, callback, profile) => {
 						return;
 					}
 
-					if (!tough.domainMatch(cookie.host_key, host, true)) {
+					if (!tough.domainMatch(host, cookie.host_key, true)) {
 						return;
 					}
 

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ function decryptAES256GCM(key, enc, nonce, tag) {
 
 const getCookies = async (uri, format, callback, profileOrPath) => {
 
-	var profile;
+	var path, profile;
 	if (fs.existsSync(profileOrPath))
 		path = profileOrPath;
 	else

--- a/index.js
+++ b/index.js
@@ -248,19 +248,25 @@ function decryptAES256GCM(key, enc, nonce, tag) {
 
 const getCookies = async (uri, format, callback, profileOrPath) => {
 
+	var profile;
+	if (fs.existsSync(profileOrPath))
+		path = profileOrPath;
+	else
+		profile = profileOrPath;
+
 	if (process.platform === 'darwin') {
 
-		path = /\//.test(profileOrPath) ? profileOrPath : process.env.HOME + `/Library/Application Support/Google/Chrome/${profileOrPath}/Cookies`;
+		path ? path : path = process.env.HOME + `/Library/Application Support/Google/Chrome/${profile}/Cookies`;
 		ITERATIONS = 1003;
 	
 	} else if (process.platform === 'linux') {
 	
-		path = /\//.test(profileOrPath) ? profileOrPath : process.env.HOME + `/.config/google-chrome/${profileOrPath}/Cookies`;
+		path ? path : path = process.env.HOME + `/.config/google-chrome/${profile}/Cookies`;
 		ITERATIONS = 1;
 	
 	} else if (process.platform === 'win32') {
 
-		path = /\\/.test(profileOrPath) ? profileOrPath : os.homedir() + `\\AppData\\Local\\Google\\Chrome\\User Data\\${profileOrPath}\\Cookies`;
+		path ? path : path = os.homedir() + `\\AppData\\Local\\Google\\Chrome\\User Data\\${profile}\\Cookies`;
 
 	} else {
 	

--- a/index.js
+++ b/index.js
@@ -248,24 +248,19 @@ function decryptAES256GCM(key, enc, nonce, tag) {
 
 const getCookies = async (uri, format, callback, profileOrPath) => {
 
-	if (/\//.test(profileOrPath))
-		path = profileOrPath;
-	else
-		profile = profileOrPath;
-
 	if (process.platform === 'darwin') {
 
-		path ? path : path = process.env.HOME + `/Library/Application Support/Google/Chrome/${profile}/Cookies`;
+		path = /\//.test(profileOrPath) ? profileOrPath : process.env.HOME + `/Library/Application Support/Google/Chrome/${profileOrPath}/Cookies`;
 		ITERATIONS = 1003;
 	
 	} else if (process.platform === 'linux') {
 	
-		path ? path : path = process.env.HOME + `/.config/google-chrome/${profile}/Cookies`;
+		path = /\//.test(profileOrPath) ? profileOrPath : process.env.HOME + `/.config/google-chrome/${profileOrPath}/Cookies`;
 		ITERATIONS = 1;
 	
 	} else if (process.platform === 'win32') {
 
-		path ? path : path = os.homedir() + `\\AppData\\Local\\Google\\Chrome\\User Data\\${profile}\\Cookies`;
+		path = /\\/.test(profileOrPath) ? profileOrPath : os.homedir() + `\\AppData\\Local\\Google\\Chrome\\User Data\\${profileOrPath}\\Cookies`;
 
 	} else {
 	

--- a/index.js
+++ b/index.js
@@ -358,7 +358,7 @@ const getCookies = async (uri, format, callback, profile) => {
 						return;
 					}
 
-					if (!tough.domainMatch(host, cookie.host_key, true)) {
+					if (!tough.domainMatch(cookie.host_key, host, true)) {
 						return;
 					}
 


### PR DESCRIPTION
A User may wish to use an arbitrary user-data-dir (for example if using chromium instead of chrome). This branch allows the user to specify either a profile (as in earlier versions) _or_ an entire path to a Cookies db.
