### PR TITLE
fix: wrong encoding bug on Apple Silicon

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ const getCookies = async (uri, format, callback, profileOrPath) => {
 			// http://tools.ietf.org/html/rfc6265#section-5.4
 
 			db.each(
-				"SELECT host_key, path, is_secure, expires_utc, name, value, encrypted_value, creation_utc, is_httponly, has_expires, is_persistent FROM cookies where host_key like '%" + domain + "' ORDER BY LENGTH(path) DESC, creation_utc ASC",
+				"SELECT host_key, path, is_secure, expires_utc, name, value, hex(encrypted_value) as encrypted_value, creation_utc, is_httponly, has_expires, is_persistent FROM cookies where host_key like '%" + domain + "' ORDER BY LENGTH(path) DESC, creation_utc ASC",
 				function (err, cookie) {
 
 					let encryptedValue;
@@ -379,7 +379,7 @@ const getCookies = async (uri, format, callback, profileOrPath) => {
 					}
 
 					if (cookie.value === '' && cookie.encrypted_value.length > 0) {
-						encryptedValue = cookie.encrypted_value;
+						encryptedValue = Buffer.from(cookie.encrypted_value, 'hex');
 
 						if (process.platform === 'win32') {
 							if (encryptedValue[0] == 0x01 && encryptedValue[1] == 0x00 && encryptedValue[2] == 0x00 && encryptedValue[3] == 0x00){


### PR DESCRIPTION
On macOS, I encountered the following error. 

```
node:internal/crypto/cipher:184
  const ret = this[kHandle].final();
                            ^

Error: error:1C80006B:Provider routines::wrong final block length
    at Decipheriv.final (node:internal/crypto/cipher:184:29)
    at decrypt (/Users/asaf/Desktop/nodejs/node_modules/chrome-cookies-secure/index.js:41:19)
    at Statement.<anonymous> (/Users/asaf/Desktop/nodejs/node_modules/chrome-cookies-secure/index.js:399:23) {
  library: 'Provider routines',
  reason: 'wrong final block length',
  code: 'ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH'
}
```

It was not related to the Node version, as I checked previous versions and received the same error. I'm using an M3 chip and am unsure if this error occurs on Intel chips as well.

The issue was that the `encrypted_value` is saved in the database as binary. When the data is retrieved from the database, it is returned as UTF-8 encoded. 
![CleanShot 2025-03-05 at 01 04 13@2x](https://github.com/user-attachments/assets/16e7a26c-02f8-42bb-99b9-80e17e26542f)

The `decrypt()` function expects to receive the value as binary. I am not sure how this works on Windows or Linux, but I believe my fix should not cause any issues on those systems. From the code, it seems you expect to receive a Buffer on Windows, so it should be fine. However, since I do not have a Windows machine, it would be a good idea to verify this before pushing.

My fix involved ensuring that the values passed to the program are returned from the database as a hex string. This way, it won't default to encoding them as UTF-8. The program then converts the hex string to a Buffer, which works on macOS as well.