### PR TITLE
Pin versions in package.json to existing package-lock versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,16 +20,16 @@
         "tough-cookie": "5.1.2"
       },
       "devDependencies": {
-        "@types/joi": "^14.3.1",
-        "joi": "^14.3.1",
-        "mocha": "^8.0.0"
+        "@types/joi": "14.3.1",
+        "joi": "14.3.1",
+        "mocha": "8.4.0"
       },
       "engines": {
         "node": ">=12.18.4"
       },
       "optionalDependencies": {
-        "keytar": "^7.9.0",
-        "win-dpapi": "^1.1.0"
+        "keytar": "7.9.0",
+        "win-dpapi": "1.1.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@types/joi": {
-      "version": "14.3.4",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.4.tgz",
-      "integrity": "sha512-1TQNDJvIKlgYXGNIABfgFp9y0FziDpuGrd799Q5RcnsDu+krD+eeW/0Fs5PHARvWWFelOhIG2OPCo6KbadBM4A==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-1kAPyOBvPPQoWOV4b1qT2SRJrQbYY9kz6h5DV8fNgSW0+/Ma+aDLQDACISC1M982uWwjAgsMEVXdalA/+IhvaA==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -2297,9 +2297,9 @@
       "optional": true
     },
     "@types/joi": {
-      "version": "14.3.4",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.4.tgz",
-      "integrity": "sha512-1TQNDJvIKlgYXGNIABfgFp9y0FziDpuGrd799Q5RcnsDu+krD+eeW/0Fs5PHARvWWFelOhIG2OPCo6KbadBM4A==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.1.tgz",
+      "integrity": "sha512-1kAPyOBvPPQoWOV4b1qT2SRJrQbYY9kz6h5DV8fNgSW0+/Ma+aDLQDACISC1M982uWwjAgsMEVXdalA/+IhvaA==",
       "dev": true
     },
     "@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "tough-cookie": "5.1.2"
   },
   "optionalDependencies": {
-    "keytar": "^7.9.0",
-    "win-dpapi": "^1.1.0"
+    "keytar": "7.9.0",
+    "win-dpapi": "1.1.0"
   },
   "devDependencies": {
-    "@types/joi": "^14.3.1",
-    "joi": "^14.3.1",
-    "mocha": "^8.0.0"
+    "@types/joi": "14.3.1",
+    "joi": "14.3.1",
+    "mocha": "8.4.0"
   },
   "engines": {
     "node": ">=12.18.4"

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -5,7 +5,6 @@ const { jarCookie, puppeteerCookie } = require('./schemas/cookies.schemas')
 
 // These tests are not part of a CI / CD
 // To run locally, they assumes you have some cookies for google.com
-
 const url = 'https://www.google.com'
 
 const isMacOS = process.platform === 'darwin'


### PR DESCRIPTION
Given recent exploits in the npm ecosystem dependency updates will be managed manually. This release locks dependencies to the versions already being used in `package-lock.json` (side from @types/joi)